### PR TITLE
update to z88dk master

### DIFF
--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/diskio.lst
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/diskio.lst
@@ -1,6 +1,5 @@
-;will be added in next commit
-;target/yaz180/driver/diskio/disk_initialize
-;target/yaz180/driver/diskio/disk_ioctl
-;target/yaz180/driver/diskio/disk_status
-;target/yaz180/driver/diskio/disk_read
-;target/yaz180/driver/diskio/disk_write
+target/yaz180/driver/diskio/z180/asm_disk_initialise
+target/yaz180/driver/diskio/z180/asm_disk_ioctl
+target/yaz180/driver/diskio/z180/asm_disk_status
+target/yaz180/driver/diskio/z180/asm_disk_read
+target/yaz180/driver/diskio/z180/asm_disk_write

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_initialise.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_initialise.asm
@@ -1,0 +1,55 @@
+SECTION code_driver
+
+PUBLIC asm_disk_initialise
+
+EXTERN ide_hard_reset
+EXTERN ide_soft_reset
+EXTERN ide_init
+
+;------------------------------------------------------------------------------
+; Routines that talk with the IDE drive, these should be called from diskio.h
+; extern DSTATUS disk_initialize (BYTE pdrv) __z88dk_fastcall;
+;
+; entry
+; l = drive number, must be 0
+;
+; exit
+; l = DSTATUS, set carry flag
+
+
+; initialize the ide drive
+
+asm_disk_initialise:
+    push af
+    xor a       ; clear a
+    or l        ; check that that it is drive 0
+    jr nz, sta_nodisk
+
+    ; hard reset the drive
+    call ide_hard_reset
+
+    ; soft reset the drive
+    call ide_soft_reset
+    jr nc, sta_noinit
+
+    ;initialize the drive. If there is no drive, this may hang
+    call ide_init
+    jr nc, sta_noinit
+
+    ld l, 0             ; set DSTATUS OK
+    pop af
+    scf                 
+    ret
+
+sta_noinit:
+    ld l, 1             ; set DSTATUS STA_NOINIT
+    pop af
+    ccf
+    ret
+
+sta_nodisk:
+    ld l, 2             ; set DSTATUS STA_NODISK
+    pop af
+    ccf
+    ret
+

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_ioctl.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_ioctl.asm
@@ -1,0 +1,139 @@
+SECTION code_driver
+
+PUBLIC asm_disk_ioctl
+
+EXTERN ide_drive_id
+EXTERN ide_cache_flush
+
+EXTERN idestatus
+
+;------------------------------------------------------------------------------
+; Routines that talk with the IDE drive, these should be called from diskio.h
+; extern DRESULT disk_ioctl (BYTE pdrv, BYTE cmd, void* buff) __z88dk_callee;
+;
+
+;
+; Command codes for disk_ioctrl function
+;
+
+; /* Generic command (Used by FatFs) */
+; #define CTRL_SYNC         0	/* Complete pending write process (_FS_READONLY == 0) */
+; #define GET_SECTOR_COUNT  1	/* Get media size (_USE_MKFS == 1) */
+; #define GET_SECTOR_SIZE   2	/* Get sector size (_MAX_SS != _MIN_SS) */
+; #define GET_BLOCK_SIZE    3	/* Get erase block size (_USE_MKFS == 1) */
+;
+; /* ATA/CF specific ioctl command */
+; #define ATA_GET_REV       20	/* Get F/W revision */
+; #define ATA_GET_MODEL     21	/* Get model name */
+; #define ATA_GET_SN        22	/* Get serial number */
+
+; entry
+; c = BYTE pdrv
+; b = BYTE cmd
+; hl = void* buff
+;
+; exit
+; b = DRESULT, set carry flag
+; hl = void* buff
+    
+; control the ide drive
+
+asm_disk_ioctl:
+    push af
+    push de
+
+    xor a       ; clear a
+    or c        ; check that that it is drive 0
+    jr nz, dresult_error
+    
+    inc b       ; start checking the cmd byte in b
+    djnz get_sector_count
+
+    call ide_cache_flush    ; cmd = 0
+    jr nc, dresult_error
+    jr dresult_ok
+
+get_sector_count:
+    djnz get_sector_size
+
+    call ide_drive_id       ; cmd = 1 get the drive id info.
+    jr nc, dresult_error
+    ld de, 10               ; prepare the sector count offset
+    ex de, hl               ; swap buffer origin to de
+    add hl, de              ; put sector count origin in hl
+    ldi
+    ldi                     ; one word
+    
+                            ; FIXME -> this count is incorrect.
+                            ; need to multiply all sector count fields.
+    jr dresult_ok
+
+get_sector_size:
+    djnz get_block_size
+
+    ld (hl), 0              ; cmd = 2
+    inc hl
+    ld (hl), 2              ; set value at pointer to 0x200 (512)
+    jr dresult_ok
+
+get_block_size:
+    djnz ata_get_rev
+
+    ld (hl), 0              ; cmd = 3
+    inc hl
+    ld (hl), 2              ; set value at pointer to 0x200 (512)
+    jr dresult_ok
+
+ata_get_rev:
+    ld a, b
+    sub 17                  ; gap to next ATA commands
+    ld b, a
+    jr nz, ata_get_model
+
+    call ide_drive_id       ; cmd = 20 get the drive firmware revision.
+    jr nc, dresult_error
+    ld bc, 8                ; number of bytes to move
+    ld de, 46               ; prepare the firmware offset
+    ex de, hl               ; swap buffer origin to de
+    add hl, de              ; put firmware origin in hl
+    ldir                    ; 8 bytes
+    jr dresult_ok
+
+ata_get_model:
+    djnz ata_get_sn
+    
+    call ide_drive_id       ; cmd = 21 get the drive model number.
+    jr nc, dresult_error
+    ld bc, 40               ; number of bytes to move
+    ld de, 54               ; prepare the model number offset
+    ex de, hl               ; swap buffer origin to de
+    add hl, de              ; put model number origin in hl
+    ldir                    ; 40 bytes
+    jr dresult_ok
+     
+ata_get_sn:
+    djnz dresult_error
+    
+    call ide_drive_id       ; cmd = 22 get the serial number.
+    jr nc, dresult_error
+    ld bc, 20               ; number of bytes to move
+    ld de, 20               ; prepare the serial number offset
+    ex de, hl               ; swap buffer origin to de
+    add hl, de              ; put serial number origin in hl
+    ldir                    ; 20 bytes
+;   jr dresult_ok
+    
+dresult_ok:
+    ld b, 0                 ; set DRESULT RES_OK
+    pop de
+    pop af
+    scf
+    ret
+
+dresult_error:
+    ld b, 1                 ; set DRESULT RES_ERROR
+    pop de
+    pop af
+    ccf
+    ret
+

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_read.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_read.asm
@@ -1,0 +1,62 @@
+SECTION code_driver
+
+PUBLIC asm_disk_read
+
+EXTERN ide_read_sector
+
+;------------------------------------------------------------------------------
+; Routines that talk with the IDE drive, these should be called from diskio.h
+;
+; DRESULT disk_read (
+;   BYTE pdrv,          /* Physical drive nmuber to identify the drive */
+;   BYTE *buff,         /* Data buffer to store read data */
+;   DWORD sector,       /* Start sector in LBA */
+;   UINT count          /* Number of sectors to read */ ) __z88dk_callee;
+;
+; entry
+; a = number of sectors (< 256)
+; bcde = LBA specified by the 4 bytes in BCDE
+; hl = the address pointer to the buffer to fill
+;
+; exit
+; a = number of read sectors (< 256), set carry flag
+; bcde = LBA following sectors written
+; hl = the address pointer to the buffer filled
+
+
+asm_disk_read:
+    push af                 ; save total sector count
+    push hl                 ; save origin pointer
+    or a                    ; check sectors != 0
+    jr z, error
+loop:
+    call ide_read_sector    ; with the logical block address in bcde, read one sector
+    jr nc, error
+    dec a
+    jr z, success
+    push bc
+    ld bc, 512
+    add hl, bc              ; increment the buffer pointer by 512 bytes
+    inc de                  ; increment the LBA lower word   
+    ld b, a                 ; free a for LBA increment testing
+    ld a, e
+    or d                    ; lower de word non-zero, therefore no carry to bc
+    ld a, b                 ; recover a value
+    pop bc                  ; recover the bc value
+    jr nz, loop
+    inc bc                  ; otherwise increment LBA upper word
+    jr loop
+    
+success:
+    pop hl
+    pop af
+    scf
+    ret
+
+error:
+    pop hl
+    pop af
+    ccf
+    ret
+
+

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_status.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_status.asm
@@ -1,0 +1,34 @@
+SECTION code_driver
+
+PUBLIC asm_disk_status
+
+;------------------------------------------------------------------------------
+; Routines that talk with the IDE drive, these should be called from diskio.h
+; extern DSTATUS disk_status (BYTE pdrv) __z88dk_fastcall;
+;
+;
+; entry
+; l = drive number, must be 0
+;
+; exit
+; l = DSTATUS, set carry flag
+
+; get the ide drive status
+
+asm_disk_status:
+    push af
+    xor a       ; clear a
+    or l        ; check that that it is drive 0
+    jr nz, sta_nodisk
+
+    ld l, 0             ; set DSTATUS OK
+    pop af
+    scf
+    ret
+
+sta_nodisk:
+    ld l, 2             ; set DSTATUS STA_NODISK
+    pop af
+    ccf
+    ret
+

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_write.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/diskio/z180/asm_disk_write.asm
@@ -1,0 +1,60 @@
+SECTION code_driver
+
+PUBLIC asm_disk_write
+
+EXTERN ide_write_sector
+
+;------------------------------------------------------------------------------
+; Routines that talk with the IDE drive, these should be called from diskio.h
+;
+; DRESULT disk_write (
+;   BYTE pdrv,          /* Physical drive nmuber to identify the drive */
+;   const BYTE *buff,   /* Data to be written */
+;   DWORD sector,       /* Start sector in LBA */
+;   UINT count          /* Number of sectors to write */ ) __z88dk_callee;
+;
+; entry
+; a = number of sectors (< 256)
+; bcde = LBA specified by the 4 bytes in BCDE
+; hl = the address pointer to the buffer to fill
+;
+; exit
+; a = number of written sectors (< 256), set carry flag
+; bcde = LBA following sectors written
+; hl = the address pointer to the buffer filled
+
+
+asm_disk_write:
+    push af                 ; save total sector count
+    push hl                 ; save origin pointer
+    or a                    ; check sectors != 0
+    jr z, error
+loop:
+    call ide_write_sector    ; with the logical block address in bcde, write one sector
+    jr nc, error
+    dec a
+    jr z, success
+    push bc
+    ld bc, 512
+    add hl, bc              ; increment the buffer pointer by 512 bytes
+    inc de                  ; increment the LBA lower word    
+    ld b, a                 ; free a for LBA increment testing
+    ld a, e
+    or d                    ; lower de word non-zero, therefore no carry to bc
+    ld a, b                 ; recover a value
+    pop bc                  ; recover the bc value
+    jr nz, loop
+    inc bc                  ; otherwise increment LBA upper word
+    jr loop
+    
+success:
+    pop hl
+    pop af
+    scf
+    ret
+
+error:
+    pop hl
+    pop af
+    ccf
+    ret

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_idle.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_idle.asm
@@ -8,6 +8,7 @@ EXTERN __IO_IDE_COMMAND
 EXTERN __IDE_CMD_IDLE
 
 EXTERN ide_wait_ready
+EXTERN ide_test_error
 
 EXTERN ide_write_byte
 
@@ -35,6 +36,5 @@ ide_idle:
 error:
     pop de 
     pop af
-    or a                    ;carry = 0 on return = operation failed
-    ret
+    jp ide_test_error       ;carry = 0 on return = operation failed
 

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_read_sector.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_read_sector.asm
@@ -3,7 +3,7 @@ SECTION code_driver
 
 PUBLIC ide_read_sector
 
-EXTERN __IO_IDE_COMMAND
+EXTERN __IO_IDE_SEC_CNT, __IO_IDE_COMMAND
 
 EXTERN __IDE_CMD_READ
 
@@ -28,6 +28,10 @@ ide_read_sector:
     call ide_wait_ready     ;make sure drive is ready
     jr nc, error
     call ide_setup_lba      ;tell it which sector we want in BCDE
+    push de
+    ld e, $1
+    ld a, __IO_IDE_SEC_CNT    
+    call ide_write_byte     ;set sector count to 1
     ld e, __IDE_CMD_READ    
     ld a, __IO_IDE_COMMAND
     call ide_write_byte     ;ask the drive to read it
@@ -36,11 +40,13 @@ ide_read_sector:
     call ide_wait_drq       ;wait until it's got the data
     jr nc, error
     call ide_read_block     ;grab the data into (HL++)
+    pop de
     pop af
     scf                     ;carry = 1 on return = operation ok
     ret
 
 error:
+    pop de
     pop af
     jp ide_test_error       ;carry = 0 on return = operation failed
 

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_setup_lba.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_setup_lba.asm
@@ -3,7 +3,6 @@ SECTION code_driver
 
 PUBLIC ide_setup_lba
 
-EXTERN __IO_IDE_SEC_CNT
 EXTERN __IO_IDE_LBA0, __IO_IDE_LBA1, __IO_IDE_LBA2, __IO_IDE_LBA3
 
 EXTERN ide_write_byte
@@ -22,6 +21,7 @@ EXTERN idestatus
     
 ide_setup_lba:
     push af
+    push de
     push hl
     ld a, __IO_IDE_LBA0
     call ide_write_byte     ;set LBA0 0:7
@@ -42,10 +42,8 @@ ide_setup_master:
     ld e, a
     ld a, __IO_IDE_LBA3
     call ide_write_byte     ;set LBA3 24:27 + bits 5:7=111
-    ld e, $1
-    ld a, __IO_IDE_SEC_CNT    
-    call ide_write_byte     ;set sector count to 1
     pop hl
+    pop de
     pop af
     ret
 

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_sleep.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_sleep.asm
@@ -8,6 +8,7 @@ EXTERN __IO_IDE_COMMAND
 EXTERN __IDE_CMD_SLEEP
 
 EXTERN ide_wait_ready
+EXTERN ide_test_error
 
 EXTERN ide_write_byte
 
@@ -35,5 +36,5 @@ ide_sleep:
 error:
     pop de 
     pop af
-    or a                    ;carry = 0 on return = operation failed
-    ret
+    jp ide_test_error       ;carry = 0 on return = operation failed
+

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_standby.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_standby.asm
@@ -8,6 +8,7 @@ EXTERN __IO_IDE_COMMAND
 EXTERN __IDE_CMD_STANDBY
 
 EXTERN ide_wait_ready
+EXTERN ide_test_error
 
 EXTERN ide_write_byte
 
@@ -35,5 +36,5 @@ ide_standby:
 error:
     pop de 
     pop af
-    or a                    ;carry = 0 on return = operation failed
-    ret
+    jp ide_test_error       ;carry = 0 on return = operation failed
+

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_test_error.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_test_error.asm
@@ -29,11 +29,11 @@ ide_test_error:
     jr nz, ide_test2        ;test write error bit
     
     ld a, __IO_IDE_ERROR    ;select error register
-    call ide_read_byte      ;get error register in A
+    call ide_read_byte      ;get error register in a
 ide_test2:
-    or a                    ;make carry flag zero = error!
     inc sp                  ;pop old af
     inc sp
+    ccf                     ;make carry flag zero = error!
     ret                     ;if a = 0, ide write busy timed out
 
 ide_test_success:

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_wait_drq.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_wait_drq.asm
@@ -24,7 +24,6 @@ ide_wait_drq:
 ide_wait_drq2:
     ld a, __IO_IDE_ALT_STATUS    ;get IDE alt status register
     call ide_read_byte
-    or a                    ;carry 0
     tst 00100001b           ;test for ERR or DFE
     jr nz, ide_wait_error
     and 10001000b           ;mask off BuSY and DRQ bits
@@ -36,6 +35,6 @@ ide_wait_drq2:
 
 ide_wait_error:
     pop af
-    or a                    ;clear carry flag on failure
+    ccf                     ;clear carry flag on failure
     ret
 

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_wait_ready.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_wait_ready.asm
@@ -27,7 +27,6 @@ ide_wait_ready:
 ide_wait_ready2:
     ld a, __IO_IDE_ALT_STATUS    ;get IDE alt status register
     call ide_read_byte
-    or a                    ;carry 0
     tst 00100001b           ;test for ERR or DFE
     jr nz, ide_wait_error
     and 11000000b           ;mask off BuSY and RDY bits
@@ -39,6 +38,6 @@ ide_wait_ready2:
 
 ide_wait_error:
     pop af
-    or a                    ;clear carry flag on failure
+    ccf                     ;clear carry flag on failure
     ret
 

--- a/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_write_sector.asm
+++ b/libsrc/_DEVELOPMENT/target/yaz180/driver/ide/ide_write_sector.asm
@@ -3,7 +3,7 @@ SECTION code_driver
 
 PUBLIC ide_write_sector
 
-EXTERN __IO_IDE_COMMAND
+EXTERN __IO_IDE_SEC_CNT, __IO_IDE_COMMAND
 
 EXTERN __IDE_CMD_WRITE, __IDE_CMD_CACHE_FLUSH
 
@@ -28,6 +28,10 @@ ide_write_sector:
     call ide_wait_ready     ;make sure drive is ready
     jr nc, error
     call ide_setup_lba      ;tell it which sector we want in BCDE
+    push de
+    ld e, $1
+    ld a, __IO_IDE_SEC_CNT    
+    call ide_write_byte     ;set sector count to 1
     ld e, __IDE_CMD_WRITE    
     ld a, __IO_IDE_COMMAND
     call ide_write_byte     ;instruct drive to write a sector
@@ -43,11 +47,13 @@ ide_write_sector:
     call ide_write_byte     ;tell drive to flush its hardware cache
     call ide_wait_ready     ;wait until the write is complete
     jr nc, error
+    pop de
     pop af
     scf                     ;carry = 1 on return = operation ok
     ret
 
 error:
+    pop de
     pop af
     jp ide_test_error       ;carry = 0 on return = operation failed
 


### PR DESCRIPTION
* rc2014 basic heap & stack relocation

* yaz180 3rd commit

* adjust rc2014 bss config

* yaz180 4th commit

* minor rc2014 & yaz180 corrections

* extend config_target for integrated hardware

* IDE via PIO 82C55 - infrastructure

* use eval() in config_target.m4

* rc2014 - add leading underscores to config_target.m4

* rc2014 - add leading __IO_

* yaz180 - convert config_target defines to double underscore

* yaz180 - handle ide errors cleanly

* add asm diskio functions