### PR TITLE
update to z88dk master

### DIFF
--- a/libsrc/_DEVELOPMENT/target/yaz180/config/config_target.m4
+++ b/libsrc/_DEVELOPMENT/target/yaz180/config/config_target.m4
@@ -172,27 +172,81 @@ define(`__IO_PCA_IMODE_CR',  0x07)              # Clock Rate (MASK)
 
 # Am9511A-1 APU Port Definitions
 
-define(`__IO_APU_PORT_BASE',  0xC000)                  # Base Address for Am9511A
-define(`__IO_APU_PORT_DATA',  eval(__IO_APU_PORT_BASE + 0x00))    # APU Data Port
-define(`__IO_APU_PORT_CONTROL',  eval(__IO_APU_PORT_BASE + 0x01))    # APU Control Port
+define(`__IO_APU_PORT_BASE',  0xC000)           # Base Address for Am9511A
+define(`__IO_APU_PORT_DATA',  eval(__IO_APU_PORT_BASE + 0x00))      # APU Data Port
+define(`__IO_APU_PORT_CONTROL', eval(__IO_APU_PORT_BASE + 0x01))    # APU Control Port
+define(`__IO_APU_PORT_STATUS',  eval(__IO_APU_PORT_BASE + 0x01))    # APU Status Port == Control Port
 
-define(`__IO_APU_OP_ENT',  0x40)
-define(`__IO_APU_OP_REM',  0x50)
-define(`__IO_APU_OP_ENT16',  0x40)
-define(`__IO_APU_OP_ENT32',  0x41)
-define(`__IO_APU_OP_REM16',  0x50)
-define(`__IO_APU_OP_REM32',  0x51)
+define(`__IO_APU_STATUS_BUSY',  0x80)
+define(`__IO_APU_STATUS_SIGN',  0x40)
+define(`__IO_APU_STATUS_ZERO',  0x20)
+define(`__IO_APU_STATUS_DIV0',  0x10)
+define(`__IO_APU_STATUS_NEGRT',  0x08)
+define(`__IO_APU_STATUS_UNDFL',  0x04)
+define(`__IO_APU_STATUS_OVRFL',  0x02)
+define(`__IO_APU_STATUS_CARRY',  0x01)
 
-define(`__IO_APU_CNTL_BUSY',  0x80)
-define(`__IO_APU_CNTL_SIGN',  0x40)
-define(`__IO_APU_CNTL_ZERO',  0x20)
-define(`__IO_APU_CNTL_DIV0',  0x10)
-define(`__IO_APU_CNTL_NEGRT',  0x08)
-define(`__IO_APU_CNTL_UNDFL',  0x04)
-define(`__IO_APU_CNTL_OVRFL',  0x02)
-define(`__IO_APU_CNTL_CARRY',  0x01)
+define(`__IO_APU_STATUS_ERROR',  0x1E)
 
-define(`__IO_APU_CNTL_ERROR',  0x1E)
+# added APU operations for driver
+define(`__IO_APU_OP_ENT',   0x40)
+define(`__IO_APU_OP_REM',   0x50)
+define(`__IO_APU_OP_ENT16', 0x40)
+define(`__IO_APU_OP_ENT32', 0x41)
+define(`__IO_APU_OP_REM16', 0x50)
+define(`__IO_APU_OP_REM32', 0x51)
+
+# 16bit fixed APU operations
+define(`__IO_APU_OP_SADD',  0x6C)
+define(`__IO_APU_OP_SSUB',  0x6D)
+define(`__IO_APU_OP_SMUL',  0x6E)
+define(`__IO_APU_OP_SMUU',  0x76)
+define(`__IO_APU_OP_SDIV',  0x6F)
+
+# 32bit fixed APU operations
+define(`__IO_APU_OP_DADD',  0x2C)
+define(`__IO_APU_OP_DSUB',  0x2D)
+define(`__IO_APU_OP_DMUL',  0x2E)
+define(`__IO_APU_OP_DMUU',  0x36)
+define(`__IO_APU_OP_DDIV',  0x2F)
+
+# 32bit floating APU operations
+define(`__IO_APU_OP_FADD',  0x10)
+define(`__IO_APU_OP_FSUB',  0x11)
+define(`__IO_APU_OP_FMUL',  0x12)
+define(`__IO_APU_OP_FDIV',  0x13)
+
+# 32bit floating derived APU operations
+define(`__IO_APU_OP_SQRT',  0x01)
+define(`__IO_APU_OP_SIN',   0x02)
+define(`__IO_APU_OP_COS',   0x03)
+define(`__IO_APU_OP_TAN',   0x04)
+define(`__IO_APU_OP_ASIN',  0x05)
+define(`__IO_APU_OP_ACOS',  0x06)
+define(`__IO_APU_OP_ATAN',  0x07)
+define(`__IO_APU_OP_LOG',   0x08)
+define(`__IO_APU_OP_LN',    0x09)
+define(`__IO_APU_OP_EXP',   0x0A)
+define(`__IO_APU_OP_PWR',   0x0B)
+
+# data and stack manipulation APU operations
+define(`__IO_APU_OP_NOP',   0x00)
+define(`__IO_APU_OP_FIXS',  0x1F)
+define(`__IO_APU_OP_FIXD',  0x1E)
+define(`__IO_APU_OP_FLTS',  0x1D)
+define(`__IO_APU_OP_FLTD',  0x1C)
+define(`__IO_APU_OP_CHSS',  0x74)
+define(`__IO_APU_OP_CHSD',  0x34)
+define(`__IO_APU_OP_PTOS',  0x15)
+define(`__IO_APU_OP_PTOD',  0x37)
+define(`__IO_APU_OP_PTOF',  0x17)
+define(`__IO_APU_OP_POPS',  0x78)
+define(`__IO_APU_OP_POPD',  0x38)
+define(`__IO_APU_OP_POPF',  0x18)
+define(`__IO_APU_OP_XCHS',  0x79)
+define(`__IO_APU_OP_XCHD',  0x39)
+define(`__IO_APU_OP_XCHF',  0x19)
+define(`__IO_APU_OP_PUPI',  0x1A)
 
 #
 # END OF USER CONFIGURATION
@@ -322,6 +376,18 @@ PUBLIC `__IO_PCA_IMODE_CR'
 PUBLIC `__IO_APU_PORT_BASE'
 PUBLIC `__IO_APU_PORT_DATA'
 PUBLIC `__IO_APU_PORT_CONTROL'
+PUBLIC `__IO_APU_PORT_STATUS'
+
+PUBLIC `__IO_APU_STATUS_BUSY'
+PUBLIC `__IO_APU_STATUS_SIGN'
+PUBLIC `__IO_APU_STATUS_ZERO'
+PUBLIC `__IO_APU_STATUS_DIV0'
+PUBLIC `__IO_APU_STATUS_NEGRT'
+PUBLIC `__IO_APU_STATUS_UNDFL'
+PUBLIC `__IO_APU_STATUS_OVRFL'
+PUBLIC `__IO_APU_STATUS_CARRY'
+
+PUBLIC `__IO_APU_STATUS_ERROR'
 
 PUBLIC `__IO_APU_OP_ENT'
 PUBLIC `__IO_APU_OP_REM'
@@ -330,16 +396,52 @@ PUBLIC `__IO_APU_OP_ENT32'
 PUBLIC `__IO_APU_OP_REM16'
 PUBLIC `__IO_APU_OP_REM32'
 
-PUBLIC `__IO_APU_CNTL_BUSY'
-PUBLIC `__IO_APU_CNTL_SIGN'
-PUBLIC `__IO_APU_CNTL_ZERO'
-PUBLIC `__IO_APU_CNTL_DIV0'
-PUBLIC `__IO_APU_CNTL_NEGRT'
-PUBLIC `__IO_APU_CNTL_UNDFL'
-PUBLIC `__IO_APU_CNTL_OVRFL'
-PUBLIC `__IO_APU_CNTL_CARRY'
+PUBLIC `__IO_APU_OP_SADD'
+PUBLIC `__IO_APU_OP_SSUB'
+PUBLIC `__IO_APU_OP_SMUL'
+PUBLIC `__IO_APU_OP_SMUU'
+PUBLIC `__IO_APU_OP_SDIV'
 
-PUBLIC `__IO_APU_CNTL_ERROR'
+PUBLIC `__IO_APU_OP_DADD'
+PUBLIC `__IO_APU_OP_DSUB'
+PUBLIC `__IO_APU_OP_DMUL'
+PUBLIC `__IO_APU_OP_DMUU'
+PUBLIC `__IO_APU_OP_DDIV'
+
+PUBLIC `__IO_APU_OP_FADD'
+PUBLIC `__IO_APU_OP_FSUB'
+PUBLIC `__IO_APU_OP_FMUL'
+PUBLIC `__IO_APU_OP_FDIV'
+
+PUBLIC `__IO_APU_OP_SQRT'
+PUBLIC `__IO_APU_OP_SIN'
+PUBLIC `__IO_APU_OP_COS'
+PUBLIC `__IO_APU_OP_TAN'
+PUBLIC `__IO_APU_OP_ASIN'
+PUBLIC `__IO_APU_OP_ACOS'
+PUBLIC `__IO_APU_OP_ATAN'
+PUBLIC `__IO_APU_OP_LOG'
+PUBLIC `__IO_APU_OP_LN'
+PUBLIC `__IO_APU_OP_EXP'
+PUBLIC `__IO_APU_OP_PWR'
+
+PUBLIC `__IO_APU_OP_NOP'
+PUBLIC `__IO_APU_OP_FIXS'
+PUBLIC `__IO_APU_OP_FIXD'
+PUBLIC `__IO_APU_OP_FLTS'
+PUBLIC `__IO_APU_OP_FLTD'
+PUBLIC `__IO_APU_OP_CHSS'
+PUBLIC `__IO_APU_OP_CHSD'
+PUBLIC `__IO_APU_OP_PTOS'
+PUBLIC `__IO_APU_OP_PTOD'
+PUBLIC `__IO_APU_OP_PTOF'
+PUBLIC `__IO_APU_OP_POPS'
+PUBLIC `__IO_APU_OP_POPD'
+PUBLIC `__IO_APU_OP_POPF'
+PUBLIC `__IO_APU_OP_XCHS'
+PUBLIC `__IO_APU_OP_XCHD'
+PUBLIC `__IO_APU_OP_XCHF'
+PUBLIC `__IO_APU_OP_PUPI'
 
 ')
 
@@ -465,6 +567,18 @@ defc `__IO_PCA_IMODE_CR' = __IO_PCA_IMODE_CR
 defc `__IO_APU_PORT_BASE' = __IO_APU_PORT_BASE
 defc `__IO_APU_PORT_DATA' = __IO_APU_PORT_DATA
 defc `__IO_APU_PORT_CONTROL' = __IO_APU_PORT_CONTROL
+defc `__IO_APU_PORT_STATUS' = __IO_APU_PORT_STATUS
+
+defc `__IO_APU_STATUS_BUSY' = __IO_APU_STATUS_BUSY
+defc `__IO_APU_STATUS_SIGN' = __IO_APU_STATUS_SIGN
+defc `__IO_APU_STATUS_ZERO' = __IO_APU_STATUS_ZERO
+defc `__IO_APU_STATUS_DIV0' = __IO_APU_STATUS_DIV0
+defc `__IO_APU_STATUS_NEGRT' = __IO_APU_STATUS_NEGRT
+defc `__IO_APU_STATUS_UNDFL' = __IO_APU_STATUS_UNDFL
+defc `__IO_APU_STATUS_OVRFL' = __IO_APU_STATUS_OVRFL
+defc `__IO_APU_STATUS_CARRY' = __IO_APU_STATUS_CARRY
+
+defc `__IO_APU_STATUS_ERROR' = __IO_APU_STATUS_ERROR
 
 defc `__IO_APU_OP_ENT' = __IO_APU_OP_ENT
 defc `__IO_APU_OP_REM' = __IO_APU_OP_REM
@@ -473,16 +587,52 @@ defc `__IO_APU_OP_ENT32' = __IO_APU_OP_ENT32
 defc `__IO_APU_OP_REM16' = __IO_APU_OP_REM16
 defc `__IO_APU_OP_REM32' = __IO_APU_OP_REM32
 
-defc `__IO_APU_CNTL_BUSY' = __IO_APU_CNTL_BUSY
-defc `__IO_APU_CNTL_SIGN' = __IO_APU_CNTL_SIGN
-defc `__IO_APU_CNTL_ZERO' = __IO_APU_CNTL_ZERO
-defc `__IO_APU_CNTL_DIV0' = __IO_APU_CNTL_DIV0
-defc `__IO_APU_CNTL_NEGRT' = __IO_APU_CNTL_NEGRT
-defc `__IO_APU_CNTL_UNDFL' = __IO_APU_CNTL_UNDFL
-defc `__IO_APU_CNTL_OVRFL' = __IO_APU_CNTL_OVRFL
-defc `__IO_APU_CNTL_CARRY' = __IO_APU_CNTL_CARRY
+defc `__IO_APU_OP_SADD' = __IO_APU_OP_SADD
+defc `__IO_APU_OP_SSUB' = __IO_APU_OP_SSUB
+defc `__IO_APU_OP_SMUL' = __IO_APU_OP_SMUL
+defc `__IO_APU_OP_SMUU' = __IO_APU_OP_SMUU
+defc `__IO_APU_OP_SDIV' = __IO_APU_OP_SDIV
 
-defc `__IO_APU_CNTL_ERROR' = __IO_APU_CNTL_ERROR
+defc `__IO_APU_OP_DADD' = __IO_APU_OP_DADD
+defc `__IO_APU_OP_DSUB' = __IO_APU_OP_DSUB
+defc `__IO_APU_OP_DMUL' = __IO_APU_OP_DMUL
+defc `__IO_APU_OP_DMUU' = __IO_APU_OP_DMUU
+defc `__IO_APU_OP_DDIV' = __IO_APU_OP_DDIV
+
+defc `__IO_APU_OP_FADD' = __IO_APU_OP_FADD
+defc `__IO_APU_OP_FSUB' = __IO_APU_OP_FSUB
+defc `__IO_APU_OP_FMUL' = __IO_APU_OP_FMUL
+defc `__IO_APU_OP_FDIV' = __IO_APU_OP_FDIV
+
+defc `__IO_APU_OP_SQRT' = __IO_APU_OP_SQRT
+defc `__IO_APU_OP_SIN' = __IO_APU_OP_SIN
+defc `__IO_APU_OP_COS' = __IO_APU_OP_COS
+defc `__IO_APU_OP_TAN' = __IO_APU_OP_TAN
+defc `__IO_APU_OP_ASIN' = __IO_APU_OP_ASIN
+defc `__IO_APU_OP_ACOS' = __IO_APU_OP_ACOS
+defc `__IO_APU_OP_ATAN' = __IO_APU_OP_ATAN
+defc `__IO_APU_OP_LOG' = __IO_APU_OP_LOG
+defc `__IO_APU_OP_LN' = __IO_APU_OP_LN
+defc `__IO_APU_OP_EXP' = __IO_APU_OP_EXP
+defc `__IO_APU_OP_PWR' = __IO_APU_OP_PWR
+
+defc `__IO_APU_OP_NOP' = __IO_APU_OP_NOP
+defc `__IO_APU_OP_FIXS' = __IO_APU_OP_FIXS
+defc `__IO_APU_OP_FIXD' = __IO_APU_OP_FIXD
+defc `__IO_APU_OP_FLTS' = __IO_APU_OP_FLTS
+defc `__IO_APU_OP_FLTD' = __IO_APU_OP_FLTD
+defc `__IO_APU_OP_CHSS' = __IO_APU_OP_CHSS
+defc `__IO_APU_OP_CHSD' = __IO_APU_OP_CHSD
+defc `__IO_APU_OP_PTOS' = __IO_APU_OP_PTOS
+defc `__IO_APU_OP_PTOD' = __IO_APU_OP_PTOD
+defc `__IO_APU_OP_PTOF' = __IO_APU_OP_PTOF
+defc `__IO_APU_OP_POPS' = __IO_APU_OP_POPS
+defc `__IO_APU_OP_POPD' = __IO_APU_OP_POPD
+defc `__IO_APU_OP_POPF' = __IO_APU_OP_POPF
+defc `__IO_APU_OP_XCHS' = __IO_APU_OP_XCHS
+defc `__IO_APU_OP_XCHD' = __IO_APU_OP_XCHD
+defc `__IO_APU_OP_XCHF' = __IO_APU_OP_XCHF
+defc `__IO_APU_OP_PUPI' = __IO_APU_OP_PUPI
 
 ')
 
@@ -611,6 +761,18 @@ ifdef(`CFG_C_DEF',
 `#define' `__IO_APU_PORT_BASE'  __IO_APU_PORT_BASE
 `#define' `__IO_APU_PORT_DATA'  __IO_APU_PORT_DATA
 `#define' `__IO_APU_PORT_CONTROL'  __IO_APU_PORT_CONTROL
+`#define' `__IO_APU_PORT_STATUS'  __IO_APU_PORT_STATUS
+
+`#define' `__IO_APU_STATUS_BUSY'  __IO_APU_STATUS_BUSY
+`#define' `__IO_APU_STATUS_SIGN'  __IO_APU_STATUS_SIGN
+`#define' `__IO_APU_STATUS_ZERO'  __IO_APU_STATUS_ZERO
+`#define' `__IO_APU_STATUS_DIV0'  __IO_APU_STATUS_DIV0
+`#define' `__IO_APU_STATUS_NEGRT'  __IO_APU_STATUS_NEGRT
+`#define' `__IO_APU_STATUS_UNDFL'  __IO_APU_STATUS_UNDFL
+`#define' `__IO_APU_STATUS_OVRFL'  __IO_APU_STATUS_OVRFL
+`#define' `__IO_APU_STATUS_CARRY'  __IO_APU_STATUS_CARRY
+
+`#define' `__IO_APU_STATUS_ERROR'  __IO_APU_STATUS_ERROR
 
 `#define' `__IO_APU_OP_ENT'  __IO_APU_OP_ENT
 `#define' `__IO_APU_OP_REM'  __IO_APU_OP_REM
@@ -619,15 +781,51 @@ ifdef(`CFG_C_DEF',
 `#define' `__IO_APU_OP_REM16'  __IO_APU_OP_REM16
 `#define' `__IO_APU_OP_REM32'  __IO_APU_OP_REM32
 
-`#define' `__IO_APU_CNTL_BUSY'  __IO_APU_CNTL_BUSY
-`#define' `__IO_APU_CNTL_SIGN'  __IO_APU_CNTL_SIGN
-`#define' `__IO_APU_CNTL_ZERO'  __IO_APU_CNTL_ZERO
-`#define' `__IO_APU_CNTL_DIV0'  __IO_APU_CNTL_DIV0
-`#define' `__IO_APU_CNTL_NEGRT'  __IO_APU_CNTL_NEGRT
-`#define' `__IO_APU_CNTL_UNDFL'  __IO_APU_CNTL_UNDFL
-`#define' `__IO_APU_CNTL_OVRFL'  __IO_APU_CNTL_OVRFL
-`#define' `__IO_APU_CNTL_CARRY'  __IO_APU_CNTL_CARRY
+`#define' `__IO_APU_OP_SADD'  __IO_APU_OP_SADD
+`#define' `__IO_APU_OP_SSUB'  __IO_APU_OP_SSUB
+`#define' `__IO_APU_OP_SMUL'  __IO_APU_OP_SMUL
+`#define' `__IO_APU_OP_SMUU'  __IO_APU_OP_SMUU
+`#define' `__IO_APU_OP_SDIV'  __IO_APU_OP_SDIV
 
-`#define' `__IO_APU_CNTL_ERROR'  __IO_APU_CNTL_ERROR
+`#define' `__IO_APU_OP_DADD'  __IO_APU_OP_DADD
+`#define' `__IO_APU_OP_DSUB'  __IO_APU_OP_DSUB
+`#define' `__IO_APU_OP_DMUL'  __IO_APU_OP_DMUL
+`#define' `__IO_APU_OP_DMUU'  __IO_APU_OP_DMUU
+`#define' `__IO_APU_OP_DDIV'  __IO_APU_OP_DDIV
+
+`#define' `__IO_APU_OP_FADD'  __IO_APU_OP_FADD
+`#define' `__IO_APU_OP_FSUB'  __IO_APU_OP_FSUB
+`#define' `__IO_APU_OP_FMUL'  __IO_APU_OP_FMUL
+`#define' `__IO_APU_OP_FDIV'  __IO_APU_OP_FDIV
+
+`#define' `__IO_APU_OP_SQRT'  __IO_APU_OP_SQRT
+`#define' `__IO_APU_OP_SIN'  __IO_APU_OP_SIN
+`#define' `__IO_APU_OP_COS'  __IO_APU_OP_COS
+`#define' `__IO_APU_OP_TAN'  __IO_APU_OP_TAN
+`#define' `__IO_APU_OP_ASIN'  __IO_APU_OP_ASIN
+`#define' `__IO_APU_OP_ACOS'  __IO_APU_OP_ACOS
+`#define' `__IO_APU_OP_ATAN'  __IO_APU_OP_ATAN
+`#define' `__IO_APU_OP_LOG'  __IO_APU_OP_LOG
+`#define' `__IO_APU_OP_LN'  __IO_APU_OP_LN
+`#define' `__IO_APU_OP_EXP'  __IO_APU_OP_EXP
+`#define' `__IO_APU_OP_PWR'  __IO_APU_OP_PWR
+
+`#define' `__IO_APU_OP_NOP'  __IO_APU_OP_NOP
+`#define' `__IO_APU_OP_FIXS'  __IO_APU_OP_FIXS
+`#define' `__IO_APU_OP_FIXD'  __IO_APU_OP_FIXD
+`#define' `__IO_APU_OP_FLTS'  __IO_APU_OP_FLTS
+`#define' `__IO_APU_OP_FLTD'  __IO_APU_OP_FLTD
+`#define' `__IO_APU_OP_CHSS'  __IO_APU_OP_CHSS
+`#define' `__IO_APU_OP_CHSD'  __IO_APU_OP_CHSD
+`#define' `__IO_APU_OP_PTOS'  __IO_APU_OP_PTOS
+`#define' `__IO_APU_OP_PTOD'  __IO_APU_OP_PTOD
+`#define' `__IO_APU_OP_PTOF'  __IO_APU_OP_PTOF
+`#define' `__IO_APU_OP_POPS'  __IO_APU_OP_POPS
+`#define' `__IO_APU_OP_POPD'  __IO_APU_OP_POPD
+`#define' `__IO_APU_OP_POPF'  __IO_APU_OP_POPF
+`#define' `__IO_APU_OP_XCHS'  __IO_APU_OP_XCHS
+`#define' `__IO_APU_OP_XCHD'  __IO_APU_OP_XCHD
+`#define' `__IO_APU_OP_XCHF'  __IO_APU_OP_XCHF
+`#define' `__IO_APU_OP_PUPI'  __IO_APU_OP_PUPI
 
 ')

--- a/libsrc/_DEVELOPMENT/target/yaz180/config/config_target.m4.bak
+++ b/libsrc/_DEVELOPMENT/target/yaz180/config/config_target.m4.bak
@@ -172,27 +172,81 @@ define(`__IO_PCA_IMODE_CR',  0x07)              # Clock Rate (MASK)
 
 # Am9511A-1 APU Port Definitions
 
-define(`__IO_APU_PORT_BASE',  0xC000)                  # Base Address for Am9511A
-define(`__IO_APU_PORT_DATA',  eval(__IO_APU_PORT_BASE + 0x00))    # APU Data Port
-define(`__IO_APU_PORT_CONTROL',  eval(__IO_APU_PORT_BASE + 0x01))    # APU Control Port
+define(`__IO_APU_PORT_BASE',  0xC000)           # Base Address for Am9511A
+define(`__IO_APU_PORT_DATA',  eval(__IO_APU_PORT_BASE + 0x00))      # APU Data Port
+define(`__IO_APU_PORT_CONTROL', eval(__IO_APU_PORT_BASE + 0x01))    # APU Control Port
+define(`__IO_APU_PORT_STATUS',  eval(__IO_APU_PORT_BASE + 0x01))    # APU Status Port == Control Port
 
-define(`__IO_APU_OP_ENT',  0x40)
-define(`__IO_APU_OP_REM',  0x50)
-define(`__IO_APU_OP_ENT16',  0x40)
-define(`__IO_APU_OP_ENT32',  0x41)
-define(`__IO_APU_OP_REM16',  0x50)
-define(`__IO_APU_OP_REM32',  0x51)
+define(`__IO_APU_STATUS_BUSY',  0x80)
+define(`__IO_APU_STATUS_SIGN',  0x40)
+define(`__IO_APU_STATUS_ZERO',  0x20)
+define(`__IO_APU_STATUS_DIV0',  0x10)
+define(`__IO_APU_STATUS_NEGRT',  0x08)
+define(`__IO_APU_STATUS_UNDFL',  0x04)
+define(`__IO_APU_STATUS_OVRFL',  0x02)
+define(`__IO_APU_STATUS_CARRY',  0x01)
 
-define(`__IO_APU_CNTL_BUSY',  0x80)
-define(`__IO_APU_CNTL_SIGN',  0x40)
-define(`__IO_APU_CNTL_ZERO',  0x20)
-define(`__IO_APU_CNTL_DIV0',  0x10)
-define(`__IO_APU_CNTL_NEGRT',  0x08)
-define(`__IO_APU_CNTL_UNDFL',  0x04)
-define(`__IO_APU_CNTL_OVRFL',  0x02)
-define(`__IO_APU_CNTL_CARRY',  0x01)
+define(`__IO_APU_STATUS_ERROR',  0x1E)
 
-define(`__IO_APU_CNTL_ERROR',  0x1E)
+# added APU operations for driver
+define(`__IO_APU_OP_ENT',   0x40)
+define(`__IO_APU_OP_REM',   0x50)
+define(`__IO_APU_OP_ENT16', 0x40)
+define(`__IO_APU_OP_ENT32', 0x41)
+define(`__IO_APU_OP_REM16', 0x50)
+define(`__IO_APU_OP_REM32', 0x51)
+
+# 16bit fixed APU operations
+define(`__IO_APU_OP_SADD',  0x6C)
+define(`__IO_APU_OP_SSUB',  0x6D)
+define(`__IO_APU_OP_SMUL',  0x6E)
+define(`__IO_APU_OP_SMUU',  0x76)
+define(`__IO_APU_OP_SDIV',  0x6F)
+
+# 32bit fixed APU operations
+define(`__IO_APU_OP_DADD',  0x2C)
+define(`__IO_APU_OP_DSUB',  0x2D)
+define(`__IO_APU_OP_DMUL',  0x2E)
+define(`__IO_APU_OP_DMUU',  0x36)
+define(`__IO_APU_OP_DDIV',  0x2F)
+
+# 32bit floating APU operations
+define(`__IO_APU_OP_FADD',  0x10)
+define(`__IO_APU_OP_FSUB',  0x11)
+define(`__IO_APU_OP_FMUL',  0x12)
+define(`__IO_APU_OP_FDIV',  0x13)
+
+# 32bit floating derived APU operations
+define(`__IO_APU_OP_SQRT',  0x01)
+define(`__IO_APU_OP_SIN',   0x02)
+define(`__IO_APU_OP_COS',   0x03)
+define(`__IO_APU_OP_TAN',   0x04)
+define(`__IO_APU_OP_ASIN',  0x05)
+define(`__IO_APU_OP_ACOS',  0x06)
+define(`__IO_APU_OP_ATAN',  0x07)
+define(`__IO_APU_OP_LOG',   0x08)
+define(`__IO_APU_OP_LN',    0x09)
+define(`__IO_APU_OP_EXP',   0x0A)
+define(`__IO_APU_OP_PWR',   0x0B)
+
+# data and stack manipulation APU operations
+define(`__IO_APU_OP_NOP',   0x00)
+define(`__IO_APU_OP_FIXS',  0x1F)
+define(`__IO_APU_OP_FIXD',  0x1E)
+define(`__IO_APU_OP_FLTS',  0x1D)
+define(`__IO_APU_OP_FLTD',  0x1C)
+define(`__IO_APU_OP_CHSS',  0x74)
+define(`__IO_APU_OP_CHSD',  0x34)
+define(`__IO_APU_OP_PTOS',  0x15)
+define(`__IO_APU_OP_PTOD',  0x37)
+define(`__IO_APU_OP_PTOF',  0x17)
+define(`__IO_APU_OP_POPS',  0x78)
+define(`__IO_APU_OP_POPD',  0x38)
+define(`__IO_APU_OP_POPF',  0x18)
+define(`__IO_APU_OP_XCHS',  0x79)
+define(`__IO_APU_OP_XCHD',  0x39)
+define(`__IO_APU_OP_XCHF',  0x19)
+define(`__IO_APU_OP_PUPI',  0x1A)
 
 #
 # END OF USER CONFIGURATION
@@ -322,6 +376,18 @@ PUBLIC `__IO_PCA_IMODE_CR'
 PUBLIC `__IO_APU_PORT_BASE'
 PUBLIC `__IO_APU_PORT_DATA'
 PUBLIC `__IO_APU_PORT_CONTROL'
+PUBLIC `__IO_APU_PORT_STATUS'
+
+PUBLIC `__IO_APU_STATUS_BUSY'
+PUBLIC `__IO_APU_STATUS_SIGN'
+PUBLIC `__IO_APU_STATUS_ZERO'
+PUBLIC `__IO_APU_STATUS_DIV0'
+PUBLIC `__IO_APU_STATUS_NEGRT'
+PUBLIC `__IO_APU_STATUS_UNDFL'
+PUBLIC `__IO_APU_STATUS_OVRFL'
+PUBLIC `__IO_APU_STATUS_CARRY'
+
+PUBLIC `__IO_APU_STATUS_ERROR'
 
 PUBLIC `__IO_APU_OP_ENT'
 PUBLIC `__IO_APU_OP_REM'
@@ -330,16 +396,52 @@ PUBLIC `__IO_APU_OP_ENT32'
 PUBLIC `__IO_APU_OP_REM16'
 PUBLIC `__IO_APU_OP_REM32'
 
-PUBLIC `__IO_APU_CNTL_BUSY'
-PUBLIC `__IO_APU_CNTL_SIGN'
-PUBLIC `__IO_APU_CNTL_ZERO'
-PUBLIC `__IO_APU_CNTL_DIV0'
-PUBLIC `__IO_APU_CNTL_NEGRT'
-PUBLIC `__IO_APU_CNTL_UNDFL'
-PUBLIC `__IO_APU_CNTL_OVRFL'
-PUBLIC `__IO_APU_CNTL_CARRY'
+PUBLIC `__IO_APU_OP_SADD'
+PUBLIC `__IO_APU_OP_SSUB'
+PUBLIC `__IO_APU_OP_SMUL'
+PUBLIC `__IO_APU_OP_SMUU'
+PUBLIC `__IO_APU_OP_SDIV'
 
-PUBLIC `__IO_APU_CNTL_ERROR'
+PUBLIC `__IO_APU_OP_DADD'
+PUBLIC `__IO_APU_OP_DSUB'
+PUBLIC `__IO_APU_OP_DMUL'
+PUBLIC `__IO_APU_OP_DMUU'
+PUBLIC `__IO_APU_OP_DDIV'
+
+PUBLIC `__IO_APU_OP_FADD'
+PUBLIC `__IO_APU_OP_FSUB'
+PUBLIC `__IO_APU_OP_FMUL'
+PUBLIC `__IO_APU_OP_FDIV'
+
+PUBLIC `__IO_APU_OP_SQRT'
+PUBLIC `__IO_APU_OP_SIN'
+PUBLIC `__IO_APU_OP_COS'
+PUBLIC `__IO_APU_OP_TAN'
+PUBLIC `__IO_APU_OP_ASIN'
+PUBLIC `__IO_APU_OP_ACOS'
+PUBLIC `__IO_APU_OP_ATAN'
+PUBLIC `__IO_APU_OP_LOG'
+PUBLIC `__IO_APU_OP_LN'
+PUBLIC `__IO_APU_OP_EXP'
+PUBLIC `__IO_APU_OP_PWR'
+
+PUBLIC `__IO_APU_OP_NOP'
+PUBLIC `__IO_APU_OP_FIXS'
+PUBLIC `__IO_APU_OP_FIXD'
+PUBLIC `__IO_APU_OP_FLTS'
+PUBLIC `__IO_APU_OP_FLTD'
+PUBLIC `__IO_APU_OP_CHSS'
+PUBLIC `__IO_APU_OP_CHSD'
+PUBLIC `__IO_APU_OP_PTOS'
+PUBLIC `__IO_APU_OP_PTOD'
+PUBLIC `__IO_APU_OP_PTOF'
+PUBLIC `__IO_APU_OP_POPS'
+PUBLIC `__IO_APU_OP_POPD'
+PUBLIC `__IO_APU_OP_POPF'
+PUBLIC `__IO_APU_OP_XCHS'
+PUBLIC `__IO_APU_OP_XCHD'
+PUBLIC `__IO_APU_OP_XCHF'
+PUBLIC `__IO_APU_OP_PUPI'
 
 ')
 
@@ -465,6 +567,18 @@ defc `__IO_PCA_IMODE_CR' = __IO_PCA_IMODE_CR
 defc `__IO_APU_PORT_BASE' = __IO_APU_PORT_BASE
 defc `__IO_APU_PORT_DATA' = __IO_APU_PORT_DATA
 defc `__IO_APU_PORT_CONTROL' = __IO_APU_PORT_CONTROL
+defc `__IO_APU_PORT_STATUS' = __IO_APU_PORT_STATUS
+
+defc `__IO_APU_STATUS_BUSY' = __IO_APU_STATUS_BUSY
+defc `__IO_APU_STATUS_SIGN' = __IO_APU_STATUS_SIGN
+defc `__IO_APU_STATUS_ZERO' = __IO_APU_STATUS_ZERO
+defc `__IO_APU_STATUS_DIV0' = __IO_APU_STATUS_DIV0
+defc `__IO_APU_STATUS_NEGRT' = __IO_APU_STATUS_NEGRT
+defc `__IO_APU_STATUS_UNDFL' = __IO_APU_STATUS_UNDFL
+defc `__IO_APU_STATUS_OVRFL' = __IO_APU_STATUS_OVRFL
+defc `__IO_APU_STATUS_CARRY' = __IO_APU_STATUS_CARRY
+
+defc `__IO_APU_STATUS_ERROR' = __IO_APU_STATUS_ERROR
 
 defc `__IO_APU_OP_ENT' = __IO_APU_OP_ENT
 defc `__IO_APU_OP_REM' = __IO_APU_OP_REM
@@ -473,16 +587,52 @@ defc `__IO_APU_OP_ENT32' = __IO_APU_OP_ENT32
 defc `__IO_APU_OP_REM16' = __IO_APU_OP_REM16
 defc `__IO_APU_OP_REM32' = __IO_APU_OP_REM32
 
-defc `__IO_APU_CNTL_BUSY' = __IO_APU_CNTL_BUSY
-defc `__IO_APU_CNTL_SIGN' = __IO_APU_CNTL_SIGN
-defc `__IO_APU_CNTL_ZERO' = __IO_APU_CNTL_ZERO
-defc `__IO_APU_CNTL_DIV0' = __IO_APU_CNTL_DIV0
-defc `__IO_APU_CNTL_NEGRT' = __IO_APU_CNTL_NEGRT
-defc `__IO_APU_CNTL_UNDFL' = __IO_APU_CNTL_UNDFL
-defc `__IO_APU_CNTL_OVRFL' = __IO_APU_CNTL_OVRFL
-defc `__IO_APU_CNTL_CARRY' = __IO_APU_CNTL_CARRY
+defc `__IO_APU_OP_SADD' = __IO_APU_OP_SADD
+defc `__IO_APU_OP_SSUB' = __IO_APU_OP_SSUB
+defc `__IO_APU_OP_SMUL' = __IO_APU_OP_SMUL
+defc `__IO_APU_OP_SMUU' = __IO_APU_OP_SMUU
+defc `__IO_APU_OP_SDIV' = __IO_APU_OP_SDIV
 
-defc `__IO_APU_CNTL_ERROR' = __IO_APU_CNTL_ERROR
+defc `__IO_APU_OP_DADD' = __IO_APU_OP_DADD
+defc `__IO_APU_OP_DSUB' = __IO_APU_OP_DSUB
+defc `__IO_APU_OP_DMUL' = __IO_APU_OP_DMUL
+defc `__IO_APU_OP_DMUU' = __IO_APU_OP_DMUU
+defc `__IO_APU_OP_DDIV' = __IO_APU_OP_DDIV
+
+defc `__IO_APU_OP_FADD' = __IO_APU_OP_FADD
+defc `__IO_APU_OP_FSUB' = __IO_APU_OP_FSUB
+defc `__IO_APU_OP_FMUL' = __IO_APU_OP_FMUL
+defc `__IO_APU_OP_FDIV' = __IO_APU_OP_FDIV
+
+defc `__IO_APU_OP_SQRT' = __IO_APU_OP_SQRT
+defc `__IO_APU_OP_SIN' = __IO_APU_OP_SIN
+defc `__IO_APU_OP_COS' = __IO_APU_OP_COS
+defc `__IO_APU_OP_TAN' = __IO_APU_OP_TAN
+defc `__IO_APU_OP_ASIN' = __IO_APU_OP_ASIN
+defc `__IO_APU_OP_ACOS' = __IO_APU_OP_ACOS
+defc `__IO_APU_OP_ATAN' = __IO_APU_OP_ATAN
+defc `__IO_APU_OP_LOG' = __IO_APU_OP_LOG
+defc `__IO_APU_OP_LN' = __IO_APU_OP_LN
+defc `__IO_APU_OP_EXP' = __IO_APU_OP_EXP
+defc `__IO_APU_OP_PWR' = __IO_APU_OP_PWR
+
+defc `__IO_APU_OP_NOP' = __IO_APU_OP_NOP
+defc `__IO_APU_OP_FIXS' = __IO_APU_OP_FIXS
+defc `__IO_APU_OP_FIXD' = __IO_APU_OP_FIXD
+defc `__IO_APU_OP_FLTS' = __IO_APU_OP_FLTS
+defc `__IO_APU_OP_FLTD' = __IO_APU_OP_FLTD
+defc `__IO_APU_OP_CHSS' = __IO_APU_OP_CHSS
+defc `__IO_APU_OP_CHSD' = __IO_APU_OP_CHSD
+defc `__IO_APU_OP_PTOS' = __IO_APU_OP_PTOS
+defc `__IO_APU_OP_PTOD' = __IO_APU_OP_PTOD
+defc `__IO_APU_OP_PTOF' = __IO_APU_OP_PTOF
+defc `__IO_APU_OP_POPS' = __IO_APU_OP_POPS
+defc `__IO_APU_OP_POPD' = __IO_APU_OP_POPD
+defc `__IO_APU_OP_POPF' = __IO_APU_OP_POPF
+defc `__IO_APU_OP_XCHS' = __IO_APU_OP_XCHS
+defc `__IO_APU_OP_XCHD' = __IO_APU_OP_XCHD
+defc `__IO_APU_OP_XCHF' = __IO_APU_OP_XCHF
+defc `__IO_APU_OP_PUPI' = __IO_APU_OP_PUPI
 
 ')
 
@@ -611,6 +761,18 @@ ifdef(`CFG_C_DEF',
 `#define' `__IO_APU_PORT_BASE'  __IO_APU_PORT_BASE
 `#define' `__IO_APU_PORT_DATA'  __IO_APU_PORT_DATA
 `#define' `__IO_APU_PORT_CONTROL'  __IO_APU_PORT_CONTROL
+`#define' `__IO_APU_PORT_STATUS'  __IO_APU_PORT_STATUS
+
+`#define' `__IO_APU_STATUS_BUSY'  __IO_APU_STATUS_BUSY
+`#define' `__IO_APU_STATUS_SIGN'  __IO_APU_STATUS_SIGN
+`#define' `__IO_APU_STATUS_ZERO'  __IO_APU_STATUS_ZERO
+`#define' `__IO_APU_STATUS_DIV0'  __IO_APU_STATUS_DIV0
+`#define' `__IO_APU_STATUS_NEGRT'  __IO_APU_STATUS_NEGRT
+`#define' `__IO_APU_STATUS_UNDFL'  __IO_APU_STATUS_UNDFL
+`#define' `__IO_APU_STATUS_OVRFL'  __IO_APU_STATUS_OVRFL
+`#define' `__IO_APU_STATUS_CARRY'  __IO_APU_STATUS_CARRY
+
+`#define' `__IO_APU_STATUS_ERROR'  __IO_APU_STATUS_ERROR
 
 `#define' `__IO_APU_OP_ENT'  __IO_APU_OP_ENT
 `#define' `__IO_APU_OP_REM'  __IO_APU_OP_REM
@@ -619,15 +781,51 @@ ifdef(`CFG_C_DEF',
 `#define' `__IO_APU_OP_REM16'  __IO_APU_OP_REM16
 `#define' `__IO_APU_OP_REM32'  __IO_APU_OP_REM32
 
-`#define' `__IO_APU_CNTL_BUSY'  __IO_APU_CNTL_BUSY
-`#define' `__IO_APU_CNTL_SIGN'  __IO_APU_CNTL_SIGN
-`#define' `__IO_APU_CNTL_ZERO'  __IO_APU_CNTL_ZERO
-`#define' `__IO_APU_CNTL_DIV0'  __IO_APU_CNTL_DIV0
-`#define' `__IO_APU_CNTL_NEGRT'  __IO_APU_CNTL_NEGRT
-`#define' `__IO_APU_CNTL_UNDFL'  __IO_APU_CNTL_UNDFL
-`#define' `__IO_APU_CNTL_OVRFL'  __IO_APU_CNTL_OVRFL
-`#define' `__IO_APU_CNTL_CARRY'  __IO_APU_CNTL_CARRY
+`#define' `__IO_APU_OP_SADD'  __IO_APU_OP_SADD
+`#define' `__IO_APU_OP_SSUB'  __IO_APU_OP_SSUB
+`#define' `__IO_APU_OP_SMUL'  __IO_APU_OP_SMUL
+`#define' `__IO_APU_OP_SMUU'  __IO_APU_OP_SMUU
+`#define' `__IO_APU_OP_SDIV'  __IO_APU_OP_SDIV
 
-`#define' `__IO_APU_CNTL_ERROR'  __IO_APU_CNTL_ERROR
+`#define' `__IO_APU_OP_DADD'  __IO_APU_OP_DADD
+`#define' `__IO_APU_OP_DSUB'  __IO_APU_OP_DSUB
+`#define' `__IO_APU_OP_DMUL'  __IO_APU_OP_DMUL
+`#define' `__IO_APU_OP_DMUU'  __IO_APU_OP_DMUU
+`#define' `__IO_APU_OP_DDIV'  __IO_APU_OP_DDIV
+
+`#define' `__IO_APU_OP_FADD'  __IO_APU_OP_FADD
+`#define' `__IO_APU_OP_FSUB'  __IO_APU_OP_FSUB
+`#define' `__IO_APU_OP_FMUL'  __IO_APU_OP_FMUL
+`#define' `__IO_APU_OP_FDIV'  __IO_APU_OP_FDIV
+
+`#define' `__IO_APU_OP_SQRT'  __IO_APU_OP_SQRT
+`#define' `__IO_APU_OP_SIN'  __IO_APU_OP_SIN
+`#define' `__IO_APU_OP_COS'  __IO_APU_OP_COS
+`#define' `__IO_APU_OP_TAN'  __IO_APU_OP_TAN
+`#define' `__IO_APU_OP_ASIN'  __IO_APU_OP_ASIN
+`#define' `__IO_APU_OP_ACOS'  __IO_APU_OP_ACOS
+`#define' `__IO_APU_OP_ATAN'  __IO_APU_OP_ATAN
+`#define' `__IO_APU_OP_LOG'  __IO_APU_OP_LOG
+`#define' `__IO_APU_OP_LN'  __IO_APU_OP_LN
+`#define' `__IO_APU_OP_EXP'  __IO_APU_OP_EXP
+`#define' `__IO_APU_OP_PWR'  __IO_APU_OP_PWR
+
+`#define' `__IO_APU_OP_NOP'  __IO_APU_OP_NOP
+`#define' `__IO_APU_OP_FIXS'  __IO_APU_OP_FIXS
+`#define' `__IO_APU_OP_FIXD'  __IO_APU_OP_FIXD
+`#define' `__IO_APU_OP_FLTS'  __IO_APU_OP_FLTS
+`#define' `__IO_APU_OP_FLTD'  __IO_APU_OP_FLTD
+`#define' `__IO_APU_OP_CHSS'  __IO_APU_OP_CHSS
+`#define' `__IO_APU_OP_CHSD'  __IO_APU_OP_CHSD
+`#define' `__IO_APU_OP_PTOS'  __IO_APU_OP_PTOS
+`#define' `__IO_APU_OP_PTOD'  __IO_APU_OP_PTOD
+`#define' `__IO_APU_OP_PTOF'  __IO_APU_OP_PTOF
+`#define' `__IO_APU_OP_POPS'  __IO_APU_OP_POPS
+`#define' `__IO_APU_OP_POPD'  __IO_APU_OP_POPD
+`#define' `__IO_APU_OP_POPF'  __IO_APU_OP_POPF
+`#define' `__IO_APU_OP_XCHS'  __IO_APU_OP_XCHS
+`#define' `__IO_APU_OP_XCHD'  __IO_APU_OP_XCHD
+`#define' `__IO_APU_OP_XCHF'  __IO_APU_OP_XCHF
+`#define' `__IO_APU_OP_PUPI'  __IO_APU_OP_PUPI
 
 ')


### PR DESCRIPTION
* rc2014 basic heap & stack relocation

* yaz180 3rd commit

* adjust rc2014 bss config

* yaz180 4th commit

* minor rc2014 & yaz180 corrections

* extend config_target for integrated hardware

* IDE via PIO 82C55 - infrastructure

* use eval() in config_target.m4

* rc2014 - add leading underscores to config_target.m4

* rc2014 - add leading __IO_

* yaz180 - convert config_target defines to double underscore

* yaz180 - handle ide errors cleanly

* add asm diskio functions

* use ccf where carry flag is cleared

* Revert "use ccf where carry flag is cleared" - complement (not clear).

This reverts commit 751efb1e7278716c137b66e18e83af1343e3f93e.

* yaz180 - ccf is complement not clear

* yaz180 - c interface for diskio

* yaz180 - 8255 IDE interface - WIP

* yaz180 - C interface for 8255 IDE interface - WIP

* yaz180 - IDE asm to working state

* yaz180 - minor copy_word improvement

* yaz180 - APU operation definitions